### PR TITLE
Update correct answer to 26q

### DIFF
--- a/26/26.txt
+++ b/26/26.txt
@@ -21,4 +21,4 @@ b. 8
 c. 12 bytes on architectures with 4 bytes pointers and 24 on architectures with 8 bytes pointers
 d. 24
 
-A: d
+A: c


### PR DESCRIPTION
Hi,
correct answer for 26 question is c. 
```
$ uname -r && go version && go run 26.go 
4.11.8-300.fc26.i686+PAE
go version go1.9.2 linux/386
struct { A float32; B string }, 12

$ uname -r && go version && go run 26.go 
4.13.5-200.fc26.x86_64
go version go1.9.1 linux/amd64
struct { A float32; B string }, 24
```
Due to "The Go Programming Language" by Brian W. Kernighan, Alan Donovan the size of string type is 2 words (data, len),  where a word is 4 bytes on a 32-bit platform and 8 bytes on a 64-bit platform. (can't find it in the language spec)

